### PR TITLE
Implement issue #8: persist activities, students, and registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # Logs and databases #
 ######################
 *.log
+*.db
 *.sql
 *.sqlite
 

--- a/src/README.md
+++ b/src/README.md
@@ -6,19 +6,21 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister students from activities
+- Persist activities, students, and registrations in SQLite
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -31,10 +33,11 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                      |
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application uses SQLite (`src/activities.db`) with meaningful identifiers:
 
 1. **Activities** - Uses activity name as identifier:
 
@@ -43,8 +46,8 @@ The application uses a simple data model with meaningful identifiers:
    - Maximum number of participants allowed
    - List of student emails who are signed up
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+2. **Students** - Uses email as identifier
 
-All data is stored in memory, which means data will be reset when the server restarts.
+3. **Registrations** - Maps students to activities
+
+Data is persisted in SQLite, so records survive server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -142,7 +142,7 @@ def initialize_database():
                     )
                     cursor.execute(
                         """
-                        INSERT INTO registrations (activity_name, student_email)
+                        INSERT OR IGNORE INTO registrations (activity_name, student_email)
                         VALUES (?, ?)
                         """,
                         (activity_name, participant_email),

--- a/src/app.py
+++ b/src/app.py
@@ -208,15 +208,22 @@ def get_activities():
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    with get_connection() as connection:
-        cursor = connection.cursor()
+    connection = sqlite3.connect(DB_PATH, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    cursor = connection.cursor()
+    try:
+        # Use BEGIN IMMEDIATE to acquire a write lock upfront, making the
+        # capacity check and insert atomic and safe under concurrent signups.
+        cursor.execute("BEGIN IMMEDIATE")
 
         cursor.execute(
-            "SELECT name FROM activities WHERE name = ?",
+            "SELECT max_participants FROM activities WHERE name = ?",
             (activity_name,),
         )
         activity = cursor.fetchone()
         if activity is None:
+            cursor.execute("ROLLBACK")
             raise HTTPException(status_code=404, detail="Activity not found")
 
         cursor.execute(
@@ -229,9 +236,22 @@ def signup_for_activity(activity_name: str, email: str):
         )
         existing_signup = cursor.fetchone()
         if existing_signup is not None:
+            cursor.execute("ROLLBACK")
             raise HTTPException(
                 status_code=400,
                 detail="Student is already signed up"
+            )
+
+        cursor.execute(
+            "SELECT COUNT(*) AS count FROM registrations WHERE activity_name = ?",
+            (activity_name,),
+        )
+        registration_count = cursor.fetchone()["count"]
+        if registration_count >= activity["max_participants"]:
+            cursor.execute("ROLLBACK")
+            raise HTTPException(
+                status_code=400,
+                detail="Activity is already full"
             )
 
         cursor.execute(
@@ -245,7 +265,13 @@ def signup_for_activity(activity_name: str, email: str):
             """,
             (activity_name, email),
         )
-        connection.commit()
+        cursor.execute("COMMIT")
+    except Exception:
+        if connection.in_transaction:
+            cursor.execute("ROLLBACK")
+        raise
+    finally:
+        connection.close()
 
     return {"message": f"Signed up {email} for {activity_name}"}
 

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,8 +20,8 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Default activities used to seed the database on first run
+DEFAULT_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -77,6 +78,122 @@ activities = {
     }
 }
 
+DB_PATH = current_dir / "activities.db"
+
+
+def get_connection():
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def initialize_database():
+    with get_connection() as connection:
+        cursor = connection.cursor()
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS activities (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS students (
+                email TEXT PRIMARY KEY
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS registrations (
+                activity_name TEXT NOT NULL,
+                student_email TEXT NOT NULL,
+                PRIMARY KEY (activity_name, student_email),
+                FOREIGN KEY (activity_name) REFERENCES activities(name) ON DELETE CASCADE,
+                FOREIGN KEY (student_email) REFERENCES students(email) ON DELETE CASCADE
+            )
+        """)
+
+        cursor.execute("SELECT COUNT(*) AS count FROM activities")
+        activity_count = cursor.fetchone()["count"]
+
+        if activity_count == 0:
+            for activity_name, details in DEFAULT_ACTIVITIES.items():
+                cursor.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        activity_name,
+                        details["description"],
+                        details["schedule"],
+                        details["max_participants"],
+                    ),
+                )
+
+                for participant_email in details["participants"]:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO students (email) VALUES (?)",
+                        (participant_email,),
+                    )
+                    cursor.execute(
+                        """
+                        INSERT INTO registrations (activity_name, student_email)
+                        VALUES (?, ?)
+                        """,
+                        (activity_name, participant_email),
+                    )
+
+        connection.commit()
+
+
+def fetch_activities():
+    with get_connection() as connection:
+        cursor = connection.cursor()
+
+        cursor.execute(
+            """
+            SELECT name, description, schedule, max_participants
+            FROM activities
+            ORDER BY name
+            """
+        )
+        activity_rows = cursor.fetchall()
+
+        cursor.execute(
+            """
+            SELECT activity_name, student_email
+            FROM registrations
+            ORDER BY activity_name, student_email
+            """
+        )
+        registration_rows = cursor.fetchall()
+
+    participants_by_activity = {}
+    for registration in registration_rows:
+        participants_by_activity.setdefault(registration["activity_name"], []).append(
+            registration["student_email"]
+        )
+
+    activities = {}
+    for activity in activity_rows:
+        activity_name = activity["name"]
+        activities[activity_name] = {
+            "description": activity["description"],
+            "schedule": activity["schedule"],
+            "max_participants": activity["max_participants"],
+            "participants": participants_by_activity.get(activity_name, []),
+        }
+
+    return activities
+
+
+initialize_database()
+
 
 @app.get("/")
 def root():
@@ -85,48 +202,90 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return fetch_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        cursor = connection.cursor()
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        cursor.execute(
+            "SELECT name FROM activities WHERE name = ?",
+            (activity_name,),
         )
+        activity = cursor.fetchone()
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Add student
-    activity["participants"].append(email)
+        cursor.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND student_email = ?
+            """,
+            (activity_name, email),
+        )
+        existing_signup = cursor.fetchone()
+        if existing_signup is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
+
+        cursor.execute(
+            "INSERT OR IGNORE INTO students (email) VALUES (?)",
+            (email,),
+        )
+        cursor.execute(
+            """
+            INSERT INTO registrations (activity_name, student_email)
+            VALUES (?, ?)
+            """,
+            (activity_name, email),
+        )
+        connection.commit()
+
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        cursor = connection.cursor()
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        cursor.execute(
+            "SELECT name FROM activities WHERE name = ?",
+            (activity_name,),
         )
+        activity = cursor.fetchone()
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Remove student
-    activity["participants"].remove(email)
+        cursor.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND student_email = ?
+            """,
+            (activity_name, email),
+        )
+        existing_signup = cursor.fetchone()
+        if existing_signup is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
+
+        cursor.execute(
+            """
+            DELETE FROM registrations
+            WHERE activity_name = ? AND student_email = ?
+            """,
+            (activity_name, email),
+        )
+        connection.commit()
+
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -81,8 +81,11 @@ DEFAULT_ACTIVITIES = {
 DB_PATH = current_dir / "activities.db"
 
 
-def get_connection():
-    connection = sqlite3.connect(DB_PATH)
+def get_connection(autocommit: bool = False):
+    # isolation_level=None enables autocommit mode, required for explicit
+    # BEGIN IMMEDIATE / COMMIT / ROLLBACK transaction control.
+    isolation_level = None if autocommit else ""
+    connection = sqlite3.connect(DB_PATH, isolation_level=isolation_level)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
     return connection
@@ -208,13 +211,15 @@ def get_activities():
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    connection = sqlite3.connect(DB_PATH, isolation_level=None)
-    connection.row_factory = sqlite3.Row
-    connection.execute("PRAGMA foreign_keys = ON")
+    # autocommit=True (isolation_level=None) is required so we can use an
+    # explicit BEGIN IMMEDIATE transaction.  In autocommit mode the standard
+    # connection.commit()/rollback() helpers are no-ops, so SQL statements
+    # are used directly for transaction control.
+    connection = get_connection(autocommit=True)
     cursor = connection.cursor()
     try:
-        # Use BEGIN IMMEDIATE to acquire a write lock upfront, making the
-        # capacity check and insert atomic and safe under concurrent signups.
+        # Acquire a write lock upfront so the capacity check and insert are
+        # atomic, preventing duplicate signups under concurrent requests.
         cursor.execute("BEGIN IMMEDIATE")
 
         cursor.execute(
@@ -223,7 +228,6 @@ def signup_for_activity(activity_name: str, email: str):
         )
         activity = cursor.fetchone()
         if activity is None:
-            cursor.execute("ROLLBACK")
             raise HTTPException(status_code=404, detail="Activity not found")
 
         cursor.execute(
@@ -236,7 +240,6 @@ def signup_for_activity(activity_name: str, email: str):
         )
         existing_signup = cursor.fetchone()
         if existing_signup is not None:
-            cursor.execute("ROLLBACK")
             raise HTTPException(
                 status_code=400,
                 detail="Student is already signed up"
@@ -248,7 +251,6 @@ def signup_for_activity(activity_name: str, email: str):
         )
         registration_count = cursor.fetchone()["count"]
         if registration_count >= activity["max_participants"]:
-            cursor.execute("ROLLBACK")
             raise HTTPException(
                 status_code=400,
                 detail="Activity is already full"


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite persistence
- add activities, students, and registrations tables
- seed default activities on first run
- preserve existing API behavior for listing, signup, and unregister
- update README for new persistence behavior

Closes #8